### PR TITLE
Feat/css/#25 CSS root 컬러 설정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,17 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --warning-color: #ce3939;
+  --main-color-1: #704718;
+  --main-color-2: #ffa944;
+  --main-color-3: #ffdd9b;
+  --bg-color-1: #fff0d2;
+  --bg-color-2: #fffae7;
+  --point-color-1: #55aeff;
+  --point-color-2: #9bd5ff;
+}
+
 @font-face {
   font-family: 'SCoreDream';
   font-weight: 100;


### PR DESCRIPTION
## 📍 관련 이슈
<!-- 관련있는 #이슈 번호를 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #이슈 번호를 적어주세요 -->
closed #25 

## ✍️ Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] CSS root 컬러 설정

## 🧑🏻‍💻 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
- 저희 정해뒀던 8가지 컬러 변수명 설정해놨습니다!

globals.css
```css
:root {
  --warning-color: #ce3939;
  --main-color-1: #704718;
  --main-color-2: #ffa944;
  --main-color-3: #ffdd9b;
  --bg-color-1: #fff0d2;
  --bg-color-2: #fffae7;
  --point-color-1: #55aeff;
  --point-color-2: #9bd5ff;
}
```
![Frame 18](https://github.com/user-attachments/assets/28550d97-4f17-4fe3-a0b5-d6213a566a40)

## 📸 스크린샷(선택)
<!-- 참고할 사진이 있다면 넣어주세요 -->
- 아래처럼 사용하시면 됩니다!
<img width="496" alt="스크린샷 2024-07-12 오후 6 39 13" src="https://github.com/user-attachments/assets/d192076a-1156-4b66-b9de-61b99d66cd52">
- warning-color 적용
<img width="397" alt="스크린샷 2024-07-12 오후 6 39 29" src="https://github.com/user-attachments/assets/0a4b366d-5d9c-4fd5-bf8f-53f31a7c091b">
